### PR TITLE
Added key import and export

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -70,12 +70,18 @@ func (b *backend) createAccount(ctx context.Context, req *logical.Request, data 
 	var err error
 
 	if keyInput != "" {
-		privateKey, err = crypto.HexToECDSA(keyInput)
+    re := regexp.MustCompile("[0-9a-fA-F]{64}$")
+    key := re.FindString(keyInput)
+    if key == "" {
+      b.Logger().Error("Input private key did not parse successfully", "privateKey", keyInput)
+      return nil, fmt.Errorf("privateKey must be a 32-byte hexidecimal string")
+    }
+		privateKey, err = crypto.HexToECDSA(key)
 		if err != nil {
 			b.Logger().Error("Error reconstructing private key from input hex", "error", err)
 			return nil, fmt.Errorf("Error reconstructing private key from input hex")
 		}
-		privateKeyString = keyInput
+		privateKeyString = key
 	} else {
 		privateKey, _ = crypto.GenerateKey()
 		privateKeyBytes := crypto.FromECDSA(privateKey)

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -39,18 +39,18 @@ const (
 
 // Account is an Ethereum account
 type Account struct {
-  Address     string   `json:"address"`
-	PrivateKey  string   `json:"private_key"`
-	PublicKey   string   `json:"public_key"`
+	Address    string `json:"address"`
+	PrivateKey string `json:"private_key"`
+	PublicKey  string `json:"public_key"`
 }
 
 func paths(b *backend) []*framework.Path {
-  return []*framework.Path{
-    pathCreateAndList(b),
-    pathReadAndDelete(b),
-    pathSign(b),
-    pathExport(b),
-  }
+	return []*framework.Path{
+		pathCreateAndList(b),
+		pathReadAndDelete(b),
+		pathSign(b),
+		pathExport(b),
+	}
 }
 
 func (b *backend) listAccounts(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
@@ -64,92 +64,92 @@ func (b *backend) listAccounts(ctx context.Context, req *logical.Request, data *
 }
 
 func (b *backend) createAccount(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-  keyInput := data.Get("privateKey").(string)
-  var privateKey *ecdsa.PrivateKey
-  var privateKeyString string
-  var err error
+	keyInput := data.Get("privateKey").(string)
+	var privateKey *ecdsa.PrivateKey
+	var privateKeyString string
+	var err error
 
-  if keyInput != "" {
-    privateKey, err = crypto.HexToECDSA(keyInput)
-    if err != nil {
-      b.Logger().Error("Error reconstructing private key from input hex", "error", err)
-      return nil, fmt.Errorf("Error reconstructing private key from input hex")
-    }
-    privateKeyString = keyInput
-  } else {
-    privateKey, _ = crypto.GenerateKey()
-    privateKeyBytes := crypto.FromECDSA(privateKey)
-    privateKeyString = hexutil.Encode(privateKeyBytes)[2:]
-  }
+	if keyInput != "" {
+		privateKey, err = crypto.HexToECDSA(keyInput)
+		if err != nil {
+			b.Logger().Error("Error reconstructing private key from input hex", "error", err)
+			return nil, fmt.Errorf("Error reconstructing private key from input hex")
+		}
+		privateKeyString = keyInput
+	} else {
+		privateKey, _ = crypto.GenerateKey()
+		privateKeyBytes := crypto.FromECDSA(privateKey)
+		privateKeyString = hexutil.Encode(privateKeyBytes)[2:]
+	}
 
-  defer ZeroKey(privateKey)
+	defer ZeroKey(privateKey)
 
-  publicKey := privateKey.Public()
-  publicKeyECDSA, _ := publicKey.(*ecdsa.PublicKey)
-  publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
-  publicKeyString := hexutil.Encode(publicKeyBytes)[4:]
+	publicKey := privateKey.Public()
+	publicKeyECDSA, _ := publicKey.(*ecdsa.PublicKey)
+	publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
+	publicKeyString := hexutil.Encode(publicKeyBytes)[4:]
 
-  hash := sha3.NewLegacyKeccak256()
-  hash.Write(publicKeyBytes[1:])
-  address := hexutil.Encode(hash.Sum(nil)[12:])
+	hash := sha3.NewLegacyKeccak256()
+	hash.Write(publicKeyBytes[1:])
+	address := hexutil.Encode(hash.Sum(nil)[12:])
 
-  accountPath := fmt.Sprintf("accounts/%s", address)
+	accountPath := fmt.Sprintf("accounts/%s", address)
 
-  accountJSON := &Account{
-    Address:      address,
-    PrivateKey:   privateKeyString,
-    PublicKey:    publicKeyString,
-  }
+	accountJSON := &Account{
+		Address:    address,
+		PrivateKey: privateKeyString,
+		PublicKey:  publicKeyString,
+	}
 
-  entry, _ := logical.StorageEntryJSON(accountPath, accountJSON)
-  err = req.Storage.Put(ctx, entry)
-  if err != nil {
+	entry, _ := logical.StorageEntryJSON(accountPath, accountJSON)
+	err = req.Storage.Put(ctx, entry)
+	if err != nil {
 		b.Logger().Error("Failed to save the new account to storage", "error", err)
-    return nil, err
-  }
+		return nil, err
+	}
 
-  return &logical.Response{
-    Data: map[string]interface{}{
-      "address":  accountJSON.Address,
-    },
-  }, nil
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"address": accountJSON.Address,
+		},
+	}, nil
 }
 
 func (b *backend) readAccount(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-  address := data.Get("name").(string)
+	address := data.Get("name").(string)
 	b.Logger().Info("Retrieving account for address", "address", address)
-  account, err := b.retrieveAccount(ctx, req, address)
-  if err != nil {
-  	return nil, err
-  }
-  if account == nil {
-  	return nil, fmt.Errorf("Account does not exist")
-  }
+	account, err := b.retrieveAccount(ctx, req, address)
+	if err != nil {
+		return nil, err
+	}
+	if account == nil {
+		return nil, fmt.Errorf("Account does not exist")
+	}
 
-  return &logical.Response{
-    Data: map[string]interface{}{
-      "address":  account.Address,
-    },
-  }, nil
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"address": account.Address,
+		},
+	}, nil
 }
 
 func (b *backend) exportAccount(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-  address := data.Get("name").(string)
-  b.Logger().Info("Retrieving account for address", "address", address)
-  account, err := b.retrieveAccount(ctx, req, address)
-  if err != nil {
-    return nil, err
-  }
-  if account == nil {
-    return nil, fmt.Errorf("Account does not exist")
-  }
+	address := data.Get("name").(string)
+	b.Logger().Info("Retrieving account for address", "address", address)
+	account, err := b.retrieveAccount(ctx, req, address)
+	if err != nil {
+		return nil, err
+	}
+	if account == nil {
+		return nil, fmt.Errorf("Account does not exist")
+	}
 
-  return &logical.Response{
-    Data: map[string]interface{}{
-      "address":  account.Address,
-      "privateKey": account.PrivateKey,
-    },
-  }, nil
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"address":    account.Address,
+			"privateKey": account.PrivateKey,
+		},
+	}, nil
 }
 
 func (b *backend) deleteAccount(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
@@ -170,121 +170,121 @@ func (b *backend) deleteAccount(ctx context.Context, req *logical.Request, data 
 }
 
 func (b *backend) retrieveAccount(ctx context.Context, req *logical.Request, address string) (*Account, error) {
-  var path string
-  matched, err := regexp.MatchString("^(0x)?[0-9a-fA-F]{40}$", address)
-  if !matched || err != nil {
-    b.Logger().Error("Failed to retrieve the account, malformatted account address", "address", address, "error", err)
-    return nil, fmt.Errorf("Failed to retrieve the account, malformatted account address")
-  } else {
-    // make sure the address has the "0x prefix"
-    if address[:2] != "0x" {
-      address = "0x" + address
-    }
-    path = fmt.Sprintf("accounts/%s", address)
-    entry, err := req.Storage.Get(ctx, path)
-    if err != nil {
-      b.Logger().Error("Failed to retrieve the account by address", "path", path, "error", err)
-      return nil, err
-    }
-    if entry == nil {
-      // could not find the corresponding key for the address
-      return nil, nil
-    }
-    var account Account
-    _ = entry.DecodeJSON(&account)
-    return &account, nil
-  }
+	var path string
+	matched, err := regexp.MatchString("^(0x)?[0-9a-fA-F]{40}$", address)
+	if !matched || err != nil {
+		b.Logger().Error("Failed to retrieve the account, malformatted account address", "address", address, "error", err)
+		return nil, fmt.Errorf("Failed to retrieve the account, malformatted account address")
+	} else {
+		// make sure the address has the "0x prefix"
+		if address[:2] != "0x" {
+			address = "0x" + address
+		}
+		path = fmt.Sprintf("accounts/%s", address)
+		entry, err := req.Storage.Get(ctx, path)
+		if err != nil {
+			b.Logger().Error("Failed to retrieve the account by address", "path", path, "error", err)
+			return nil, err
+		}
+		if entry == nil {
+			// could not find the corresponding key for the address
+			return nil, nil
+		}
+		var account Account
+		_ = entry.DecodeJSON(&account)
+		return &account, nil
+	}
 }
 
 func (b *backend) signTx(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-  from := data.Get("name").(string)
+	from := data.Get("name").(string)
 
-  var txDataToSign []byte
-  dataInput := data.Get("data").(string)
-  // some client such as go-ethereum uses "input" instead of "data"
-  if dataInput == "" {
-    dataInput = data.Get("input").(string)
-  }
-  if len(dataInput) > 2 && dataInput[0:2] != "0x" {
-    dataInput = "0x" + dataInput
-  }
+	var txDataToSign []byte
+	dataInput := data.Get("data").(string)
+	// some client such as go-ethereum uses "input" instead of "data"
+	if dataInput == "" {
+		dataInput = data.Get("input").(string)
+	}
+	if len(dataInput) > 2 && dataInput[0:2] != "0x" {
+		dataInput = "0x" + dataInput
+	}
 
-  txDataToSign, err := hexutil.Decode(dataInput)
-  if err != nil {
+	txDataToSign, err := hexutil.Decode(dataInput)
+	if err != nil {
 		b.Logger().Error("Failed to decode payload for the 'data' field", "error", err)
-    return nil, err
-  }
+		return nil, err
+	}
 
-  account, err := b.retrieveAccount(ctx, req, from)
-  if err != nil {
+	account, err := b.retrieveAccount(ctx, req, from)
+	if err != nil {
 		b.Logger().Error("Failed to retrieve the signing account", "address", from, "error", err)
-    return nil, fmt.Errorf("Error retrieving signing account %s", from)
-  }
-  if account == nil {
-    return nil, fmt.Errorf("Signing account %s does not exist", from)
-  }
-  amount := ValidNumber(data.Get("value").(string))
-  if amount == nil {
+		return nil, fmt.Errorf("Error retrieving signing account %s", from)
+	}
+	if account == nil {
+		return nil, fmt.Errorf("Signing account %s does not exist", from)
+	}
+	amount := ValidNumber(data.Get("value").(string))
+	if amount == nil {
 		b.Logger().Error("Invalid amount for the 'value' field", "value", data.Get("value").(string))
-    return nil, fmt.Errorf("Invalid amount for the 'value' field")
-  }
+		return nil, fmt.Errorf("Invalid amount for the 'value' field")
+	}
 
-  rawAddressTo := data.Get("to").(string)
+	rawAddressTo := data.Get("to").(string)
 
-  chainId := ValidNumber(data.Get("chainId").(string))
-  if chainId == nil {
+	chainId := ValidNumber(data.Get("chainId").(string))
+	if chainId == nil {
 		b.Logger().Error("Invalid chainId", "chainId", data.Get("chainId").(string))
-    return nil, fmt.Errorf("Invalid 'chainId' value")
-  }
+		return nil, fmt.Errorf("Invalid 'chainId' value")
+	}
 
-  gasLimitIn := ValidNumber(data.Get("gas").(string))
-  if gasLimitIn == nil {
+	gasLimitIn := ValidNumber(data.Get("gas").(string))
+	if gasLimitIn == nil {
 		b.Logger().Error("Invalid gas limit", "gas", data.Get("gas").(string))
-    return nil, fmt.Errorf("Invalid gas limit")
-  }
-  gasLimit := gasLimitIn.Uint64()
+		return nil, fmt.Errorf("Invalid gas limit")
+	}
+	gasLimit := gasLimitIn.Uint64()
 
-  gasPrice := ValidNumber(data.Get("gasPrice").(string))
+	gasPrice := ValidNumber(data.Get("gasPrice").(string))
 
-  privateKey, err := crypto.HexToECDSA(account.PrivateKey)
-  if err != nil {
+	privateKey, err := crypto.HexToECDSA(account.PrivateKey)
+	if err != nil {
 		b.Logger().Error("Error reconstructing private key from retrieved hex", "error", err)
-    return nil, fmt.Errorf("Error reconstructing private key from retrieved hex")
-  }
-  defer ZeroKey(privateKey)
+		return nil, fmt.Errorf("Error reconstructing private key from retrieved hex")
+	}
+	defer ZeroKey(privateKey)
 
-  nonceIn := ValidNumber(data.Get("nonce").(string))
-  var nonce uint64
-  nonce = nonceIn.Uint64()
+	nonceIn := ValidNumber(data.Get("nonce").(string))
+	var nonce uint64
+	nonce = nonceIn.Uint64()
 
-  var tx *types.Transaction
-  if rawAddressTo == "" {
-    tx = types.NewContractCreation(nonce, amount, gasLimit, gasPrice, txDataToSign)
-  } else {
-    toAddress := common.HexToAddress(rawAddressTo)
-    tx = types.NewTransaction(nonce, toAddress, amount, gasLimit, gasPrice, txDataToSign)
-  }
-  var signer types.Signer
-  if big.NewInt(0).Cmp(chainId) == 0 {
-    signer = types.HomesteadSigner{}
-  } else {
-    signer = types.NewEIP155Signer(chainId)
-  }
-  signedTx, err := types.SignTx(tx, signer, privateKey)
-  if err != nil {
+	var tx *types.Transaction
+	if rawAddressTo == "" {
+		tx = types.NewContractCreation(nonce, amount, gasLimit, gasPrice, txDataToSign)
+	} else {
+		toAddress := common.HexToAddress(rawAddressTo)
+		tx = types.NewTransaction(nonce, toAddress, amount, gasLimit, gasPrice, txDataToSign)
+	}
+	var signer types.Signer
+	if big.NewInt(0).Cmp(chainId) == 0 {
+		signer = types.HomesteadSigner{}
+	} else {
+		signer = types.NewEIP155Signer(chainId)
+	}
+	signedTx, err := types.SignTx(tx, signer, privateKey)
+	if err != nil {
 		b.Logger().Error("Failed to sign the transaction object", "error", err)
-    return nil, err
-  }
+		return nil, err
+	}
 
-  var signedTxBuff bytes.Buffer
-  signedTx.EncodeRLP(&signedTxBuff)
+	var signedTxBuff bytes.Buffer
+	signedTx.EncodeRLP(&signedTxBuff)
 
-  return &logical.Response{
-    Data: map[string]interface{}{
-      "transaction_hash":   signedTx.Hash().Hex(),
-      "signed_transaction": hexutil.Encode(signedTxBuff.Bytes()),
-    },
-  }, nil
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"transaction_hash":   signedTx.Hash().Hex(),
+			"signed_transaction": hexutil.Encode(signedTxBuff.Bytes()),
+		},
+	}, nil
 }
 
 func ValidNumber(input string) *big.Int {
@@ -300,8 +300,8 @@ func ValidNumber(input string) *big.Int {
 }
 
 func ZeroKey(k *ecdsa.PrivateKey) {
-  b := k.D.Bits()
-  for i := range b {
-    b[i] = 0
-  }
+	b := k.D.Bits()
+	for i := range b {
+		b[i] = 0
+	}
 }

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -15,547 +15,547 @@
 package backend
 
 import (
-  "bytes"
-  "context"
-  "errors"
-  "math/big"
-  "reflect"
-  "strings"
-  "testing"
-  "time"
+	"bytes"
+	"context"
+	"errors"
+	"math/big"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
 
-  "github.com/ethereum/go-ethereum/common/hexutil"
-  "github.com/ethereum/go-ethereum/core/types"
-  "github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 
-  log "github.com/hashicorp/go-hclog"
-  "github.com/hashicorp/vault/sdk/helper/logging"
-  "github.com/hashicorp/vault/sdk/logical"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/sdk/logical"
 
-  "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func getBackend(t *testing.T) (logical.Backend, logical.Storage) {
-  config := &logical.BackendConfig{
-    Logger:      logging.NewVaultLogger(log.Trace),
-    System:      &logical.StaticSystemView{},
-    StorageView: &logical.InmemStorage{},
-    BackendUUID: "test",
-  }
+	config := &logical.BackendConfig{
+		Logger:      logging.NewVaultLogger(log.Trace),
+		System:      &logical.StaticSystemView{},
+		StorageView: &logical.InmemStorage{},
+		BackendUUID: "test",
+	}
 
-  b, err := Factory(context.Background(), config)
-  if err != nil {
-    t.Fatalf("unable to create backend: %v", err)
-  }
+	b, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatalf("unable to create backend: %v", err)
+	}
 
-  // Wait for the upgrade to finish
-  time.Sleep(time.Second)
+	// Wait for the upgrade to finish
+	time.Sleep(time.Second)
 
-  return b, config.StorageView
+	return b, config.StorageView
 }
 
 type StorageMock struct {
-  switches []int
+	switches []int
 }
+
 func (s StorageMock) List(c context.Context, path string) ([]string, error) {
-  if s.switches[0] == 1 {
-    return []string{"key1", "key2"}, nil
-  } else {
-    return nil, errors.New("Bang for List!")
-  }
+	if s.switches[0] == 1 {
+		return []string{"key1", "key2"}, nil
+	} else {
+		return nil, errors.New("Bang for List!")
+	}
 }
 func (s StorageMock) Get(c context.Context, path string) (*logical.StorageEntry, error) {
-  if s.switches[1] == 2 {
-    var entry logical.StorageEntry
-    return &entry, nil
-  } else if s.switches[1] == 1 {
-    return nil, nil
-  } else {
-    return nil, errors.New("Bang for Get!")
-  }
+	if s.switches[1] == 2 {
+		var entry logical.StorageEntry
+		return &entry, nil
+	} else if s.switches[1] == 1 {
+		return nil, nil
+	} else {
+		return nil, errors.New("Bang for Get!")
+	}
 }
 func (s StorageMock) Put(c context.Context, se *logical.StorageEntry) error {
-  return errors.New("Bang for Put!")
-}  
+	return errors.New("Bang for Put!")
+}
 func (s StorageMock) Delete(c context.Context, path string) error {
-  return errors.New("Bang for Delete!")
+	return errors.New("Bang for Delete!")
 }
 
 func newStorageMock() StorageMock {
-  var sm StorageMock
-  sm.switches = []int{0, 0, 0, 0}
-  return sm
+	var sm StorageMock
+	sm.switches = []int{0, 0, 0, 0}
+	return sm
 }
 
 func TestAccounts(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
+	b, _ := getBackend(t)
 
-  // create key1
-  req := logical.TestRequest(t, logical.UpdateOperation, "accounts")
-  storage := req.Storage
-  res, err := b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
+	// create key1
+	req := logical.TestRequest(t, logical.UpdateOperation, "accounts")
+	storage := req.Storage
+	res, err := b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-  address1 := res.Data["address"].(string)
+	address1 := res.Data["address"].(string)
 
-  // create key2
-  req = logical.TestRequest(t, logical.UpdateOperation, "accounts")
-  req.Storage = storage
-  res, err = b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
+	// create key2
+	req = logical.TestRequest(t, logical.UpdateOperation, "accounts")
+	req.Storage = storage
+	res, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-  address2 := res.Data["address"].(string)
+	address2 := res.Data["address"].(string)
 
-  req = logical.TestRequest(t, logical.ListOperation, "accounts")
-  req.Storage = storage
-  resp, err := b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
+	req = logical.TestRequest(t, logical.ListOperation, "accounts")
+	req.Storage = storage
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-  expected1 := &logical.Response{
-    Data: map[string]interface{}{
-      "keys": []string{address1, address2},
-    },
-  }
-  expected2 := &logical.Response{
-    Data: map[string]interface{}{
-      "keys": []string{address2, address1},
-    },
-  }
+	expected1 := &logical.Response{
+		Data: map[string]interface{}{
+			"keys": []string{address1, address2},
+		},
+	}
+	expected2 := &logical.Response{
+		Data: map[string]interface{}{
+			"keys": []string{address2, address1},
+		},
+	}
 
-  if !reflect.DeepEqual(resp, expected1) && !reflect.DeepEqual(resp, expected2) {
-    t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected1, resp)
-  }
+	if !reflect.DeepEqual(resp, expected1) && !reflect.DeepEqual(resp, expected2) {
+		t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected1, resp)
+	}
 
-  // read account by address
-  expected := &logical.Response{
-    Data: map[string]interface{}{
-      "address": address1,
-    },
-  }
-  req = logical.TestRequest(t, logical.ReadOperation, "accounts/" + address1)
-  req.Storage = storage
-  resp, err = b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
-  if !reflect.DeepEqual(resp, expected) {
-    t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected, resp)
-  }
+	// read account by address
+	expected := &logical.Response{
+		Data: map[string]interface{}{
+			"address": address1,
+		},
+	}
+	req = logical.TestRequest(t, logical.ReadOperation, "accounts/"+address1)
+	req.Storage = storage
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(resp, expected) {
+		t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected, resp)
+	}
 
-  // read account by address without the "0x" prefix
-  req = logical.TestRequest(t, logical.ReadOperation, "accounts/" + address1[2:])
-  req.Storage = storage
-  resp, err = b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
-  if !reflect.DeepEqual(resp, expected) {
-    t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected, resp)
-  }
+	// read account by address without the "0x" prefix
+	req = logical.TestRequest(t, logical.ReadOperation, "accounts/"+address1[2:])
+	req.Storage = storage
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(resp, expected) {
+		t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected, resp)
+	}
 
-  // sign contract creation TX by address using Homestead signer
-  dataToSign := "608060405234801561001057600080fd5b506040516020806101d783398101604052516000556101a3806100346000396000f3006080604052600436106100615763ffffffff7c01000000000000000000000000000000000000000000000000000000006000350416632a1afcd981146100665780632c46b2051461008d57806360fe47b1146100a25780636d4ce63c1461008d575b600080fd5b34801561007257600080fd5b5061007b6100ba565b60408051918252519081900360200190f35b34801561009957600080fd5b5061007b6100c0565b3480156100ae57600080fd5b5061007b6004356100c6565b60005481565b60005490565b60006064821061013757604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601960248201527f56616c75652063616e206e6f74206265206f7665722031303000000000000000604482015290519081900360640190fd5b60008290556040805183815290517f9455957c3b77d1d4ed071e2b469dd77e37fc5dfd3b4d44dc8a997cc97c7b3d499181900360200190a15050600054905600a165627a7a72305820a22d4674e519555e6f065ccf98b5bd479e108895cbddc10cba200c775d0008730029000000000000000000000000000000000000000000000000000000000000000a"
-  req = logical.TestRequest(t, logical.CreateOperation, "accounts/" + address1 + "/sign")
-  req.Storage = storage
-  data := map[string]interface{}{
-    "data": dataToSign,
-    "gas": 500000,
-    "nonce": "0x2",
-    "gasPrice": 0,
-  }
-  req.Data = data
-  resp, err = b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
-  signedTx := resp.Data["signed_transaction"].(string)
-  signatureBytes, err := hexutil.Decode(signedTx)
-  var tx types.Transaction
-  err = tx.DecodeRLP(rlp.NewStream(bytes.NewReader(signatureBytes), 0))
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
-  v, _, _ := tx.RawSignatureValues()
-  assert.Equal(true, contains([]*big.Int{big.NewInt(27), big.NewInt(28)}, v))
+	// sign contract creation TX by address using Homestead signer
+	dataToSign := "608060405234801561001057600080fd5b506040516020806101d783398101604052516000556101a3806100346000396000f3006080604052600436106100615763ffffffff7c01000000000000000000000000000000000000000000000000000000006000350416632a1afcd981146100665780632c46b2051461008d57806360fe47b1146100a25780636d4ce63c1461008d575b600080fd5b34801561007257600080fd5b5061007b6100ba565b60408051918252519081900360200190f35b34801561009957600080fd5b5061007b6100c0565b3480156100ae57600080fd5b5061007b6004356100c6565b60005481565b60005490565b60006064821061013757604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601960248201527f56616c75652063616e206e6f74206265206f7665722031303000000000000000604482015290519081900360640190fd5b60008290556040805183815290517f9455957c3b77d1d4ed071e2b469dd77e37fc5dfd3b4d44dc8a997cc97c7b3d499181900360200190a15050600054905600a165627a7a72305820a22d4674e519555e6f065ccf98b5bd479e108895cbddc10cba200c775d0008730029000000000000000000000000000000000000000000000000000000000000000a"
+	req = logical.TestRequest(t, logical.CreateOperation, "accounts/"+address1+"/sign")
+	req.Storage = storage
+	data := map[string]interface{}{
+		"data":     dataToSign,
+		"gas":      500000,
+		"nonce":    "0x2",
+		"gasPrice": 0,
+	}
+	req.Data = data
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	signedTx := resp.Data["signed_transaction"].(string)
+	signatureBytes, err := hexutil.Decode(signedTx)
+	var tx types.Transaction
+	err = tx.DecodeRLP(rlp.NewStream(bytes.NewReader(signatureBytes), 0))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	v, _, _ := tx.RawSignatureValues()
+	assert.Equal(true, contains([]*big.Int{big.NewInt(27), big.NewInt(28)}, v))
 
-  sender, _ := types.Sender(types.HomesteadSigner{}, &tx)
-  assert.Equal(address1, strings.ToLower(sender.Hex()))
+	sender, _ := types.Sender(types.HomesteadSigner{}, &tx)
+	assert.Equal(address1, strings.ToLower(sender.Hex()))
 
-  // sign TX by address without "0x" using EIP155 signer
-  dataToSign = "60fe47b10000000000000000000000000000000000000000000000000000000000000014"
-  req = logical.TestRequest(t, logical.CreateOperation, "accounts/" + address2[2:] + "/sign")
-  req.Storage = storage
-  data = map[string]interface{}{
-    "data": dataToSign,
-    "to": "0xf809410b0d6f047c603deb311979cd413e025a84",
-    "gas": 50000,
-    "nonce": "0x3",
-    "gasPrice": 0,
-    "chainId": 12345,
-  }
-  req.Data = data
-  resp, err = b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
-  signedTx = resp.Data["signed_transaction"].(string)
-  signatureBytes, err = hexutil.Decode(signedTx)
-  err = tx.DecodeRLP(rlp.NewStream(bytes.NewReader(signatureBytes), 0))
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
-  v, _, _ = tx.RawSignatureValues()
-  assert.Equal(true, contains([]*big.Int{big.NewInt(24725), big.NewInt(24726)}, v))
+	// sign TX by address without "0x" using EIP155 signer
+	dataToSign = "60fe47b10000000000000000000000000000000000000000000000000000000000000014"
+	req = logical.TestRequest(t, logical.CreateOperation, "accounts/"+address2[2:]+"/sign")
+	req.Storage = storage
+	data = map[string]interface{}{
+		"data":     dataToSign,
+		"to":       "0xf809410b0d6f047c603deb311979cd413e025a84",
+		"gas":      50000,
+		"nonce":    "0x3",
+		"gasPrice": 0,
+		"chainId":  12345,
+	}
+	req.Data = data
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	signedTx = resp.Data["signed_transaction"].(string)
+	signatureBytes, err = hexutil.Decode(signedTx)
+	err = tx.DecodeRLP(rlp.NewStream(bytes.NewReader(signatureBytes), 0))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	v, _, _ = tx.RawSignatureValues()
+	assert.Equal(true, contains([]*big.Int{big.NewInt(24725), big.NewInt(24726)}, v))
 
-  sender, _ = types.Sender(types.HomesteadSigner{}, &tx)
-  assert.Equal(address1, strings.ToLower(sender.Hex()))
+	sender, _ = types.Sender(types.HomesteadSigner{}, &tx)
+	assert.Equal(address1, strings.ToLower(sender.Hex()))
 
-  data = map[string]interface{}{
-    "input": dataToSign,
-    "to": "0xf809410b0d6f047c603deb311979cd413e025a84",
-    "gas": 50000,
-    "nonce": "0x3",
-    "gasPrice": 0,
-    "chainId": 12345,
-  }
-  req.Data = data
-  resp, err = b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
+	data = map[string]interface{}{
+		"input":    dataToSign,
+		"to":       "0xf809410b0d6f047c603deb311979cd413e025a84",
+		"gas":      50000,
+		"nonce":    "0x3",
+		"gasPrice": 0,
+		"chainId":  12345,
+	}
+	req.Data = data
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-  // delete key by name
-  req = logical.TestRequest(t, logical.DeleteOperation, "accounts/" + address1)
-  req.Storage = storage
-  if _, err := b.HandleRequest(context.Background(), req); err != nil {
-    t.Fatalf("err: %v", err)
-  }
+	// delete key by name
+	req = logical.TestRequest(t, logical.DeleteOperation, "accounts/"+address1)
+	req.Storage = storage
+	if _, err := b.HandleRequest(context.Background(), req); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-  expected = &logical.Response{
-    Data: map[string]interface{}{},
-  }
+	expected = &logical.Response{
+		Data: map[string]interface{}{},
+	}
 
-  // delete key by address
-  req = logical.TestRequest(t, logical.DeleteOperation, "accounts/" + address2)
-  req.Storage = storage
-  if _, err := b.HandleRequest(context.Background(), req); err != nil {
-    t.Fatalf("err: %v", err)
-  }
+	// delete key by address
+	req = logical.TestRequest(t, logical.DeleteOperation, "accounts/"+address2)
+	req.Storage = storage
+	if _, err := b.HandleRequest(context.Background(), req); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-  req = logical.TestRequest(t, logical.ListOperation, "accounts")
-  req.Storage = storage
-  resp, err = b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
+	req = logical.TestRequest(t, logical.ListOperation, "accounts")
+	req.Storage = storage
+	resp, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-  if !reflect.DeepEqual(resp, expected) {
-    t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected, resp)
-  }
+	if !reflect.DeepEqual(resp, expected) {
+		t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected, resp)
+	}
 
-  // import key3
-  req = logical.TestRequest(t, logical.UpdateOperation, "accounts")
-  req.Storage = storage
-  data = map[string]interface{}{
-    "privateKey": "ec85999367d32fbbe02dd600a2a44550b95274cc67d14375a9f0bce233f13ad2",
-  }
-  req.Data = data
-  res, err = b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
-  address3 := res.Data["address"].(string)  
-  assert.Equal("0xd5bcc62d9b1087a5cfec116c24d6187dd40fdf8a", address3)
+	// import key3
+	req = logical.TestRequest(t, logical.UpdateOperation, "accounts")
+	req.Storage = storage
+	data = map[string]interface{}{
+		"privateKey": "ec85999367d32fbbe02dd600a2a44550b95274cc67d14375a9f0bce233f13ad2",
+	}
+	req.Data = data
+	res, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	address3 := res.Data["address"].(string)
+	assert.Equal("0xd5bcc62d9b1087a5cfec116c24d6187dd40fdf8a", address3)
 
-  // export key3
-  req = logical.TestRequest(t, logical.ReadOperation, "export/accounts/0xd5bcc62d9b1087a5cfec116c24d6187dd40fdf8a")
-  req.Storage = storage
-  res, err = b.HandleRequest(context.Background(), req)
-  if err != nil {
-    t.Fatalf("err: %v", err)
-  }
-  assert.Equal("ec85999367d32fbbe02dd600a2a44550b95274cc67d14375a9f0bce233f13ad2", res.Data["privateKey"])
+	// export key3
+	req = logical.TestRequest(t, logical.ReadOperation, "export/accounts/0xd5bcc62d9b1087a5cfec116c24d6187dd40fdf8a")
+	req.Storage = storage
+	res, err = b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal("ec85999367d32fbbe02dd600a2a44550b95274cc67d14375a9f0bce233f13ad2", res.Data["privateKey"])
 }
 
 func TestListAccountsFailure1(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.ListOperation, "accounts")
-  sm := newStorageMock()
-  req.Storage = sm
-  _, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.ListOperation, "accounts")
+	sm := newStorageMock()
+	req.Storage = sm
+	_, err := b.HandleRequest(context.Background(), req)
 
-  assert.Equal("Bang for List!", err.Error())
+	assert.Equal("Bang for List!", err.Error())
 }
 
 func TestCreateAccountsFailure1(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.UpdateOperation, "accounts")
-  sm := newStorageMock()
-  req.Storage = sm
-  _, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.UpdateOperation, "accounts")
+	sm := newStorageMock()
+	req.Storage = sm
+	_, err := b.HandleRequest(context.Background(), req)
 
-  assert.Equal("Bang for Put!", err.Error())
+	assert.Equal("Bang for Put!", err.Error())
 }
 
 func TestCreateAccountsFailure2(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.UpdateOperation, "accounts")
-  data := map[string]interface{}{
-    "privateKey": "abc",
-  }
-  req.Data = data
-  sm := newStorageMock()
-  req.Storage = sm
-  _, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.UpdateOperation, "accounts")
+	data := map[string]interface{}{
+		"privateKey": "abc",
+	}
+	req.Data = data
+	sm := newStorageMock()
+	req.Storage = sm
+	_, err := b.HandleRequest(context.Background(), req)
 
-  assert.Equal("Error reconstructing private key from input hex", err.Error())
+	assert.Equal("Error reconstructing private key from input hex", err.Error())
 }
 
 func TestReadAccountsFailure1(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.ReadOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
-  sm := newStorageMock()
-  req.Storage = sm
-  _, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.ReadOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
+	sm := newStorageMock()
+	req.Storage = sm
+	_, err := b.HandleRequest(context.Background(), req)
 
-  assert.Equal("Bang for Get!", err.Error())
+	assert.Equal("Bang for Get!", err.Error())
 }
 
 func TestReadAccountsFailure2(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.ReadOperation, "accounts/key1")
-  sm := newStorageMock()
-  sm.switches[1] = 1
-  req.Storage = sm
-  resp, _ := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.ReadOperation, "accounts/key1")
+	sm := newStorageMock()
+	sm.switches[1] = 1
+	req.Storage = sm
+	resp, _ := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
+	assert.Nil(resp)
 }
 
 func TestReadAccountsFailure3(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.ReadOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
-  sm := newStorageMock()
-  req.Storage = sm
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.ReadOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
+	sm := newStorageMock()
+	req.Storage = sm
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Bang for Get!", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Bang for Get!", err.Error())
 }
 
 func TestReadAccountsFailure4(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.ReadOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
-  sm := newStorageMock()
-  sm.switches[1] = 1
-  req.Storage = sm
-  resp, _ := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.ReadOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
+	sm := newStorageMock()
+	sm.switches[1] = 1
+	req.Storage = sm
+	resp, _ := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
+	assert.Nil(resp)
 }
 
 func TestExportAccountsFailure1(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.ReadOperation, "export/accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
-  sm := newStorageMock()
-  req.Storage = sm
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.ReadOperation, "export/accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
+	sm := newStorageMock()
+	req.Storage = sm
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Bang for Get!", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Bang for Get!", err.Error())
 }
 
 func TestExportAccountsFailure2(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.ReadOperation, "export/accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
-  sm := newStorageMock()
-  sm.switches[1] = 1
-  req.Storage = sm
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.ReadOperation, "export/accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
+	sm := newStorageMock()
+	sm.switches[1] = 1
+	req.Storage = sm
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Account does not exist", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Account does not exist", err.Error())
 }
 
 func TestDeleteAccountsFailure1(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.DeleteOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
-  sm := newStorageMock()
-  req.Storage = sm
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.DeleteOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
+	sm := newStorageMock()
+	req.Storage = sm
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Bang for Get!", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Bang for Get!", err.Error())
 }
 
 func TestDeleteAccountsFailure2(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.DeleteOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
-  sm := newStorageMock()
-  sm.switches[1] = 1
-  req.Storage = sm
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.DeleteOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
+	sm := newStorageMock()
+	sm.switches[1] = 1
+	req.Storage = sm
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Nil(err)
+	assert.Nil(resp)
+	assert.Nil(err)
 }
 
 func TestDeleteAccountsFailure3(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.DeleteOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
-  sm := newStorageMock()
-  sm.switches[1] = 2
-  req.Storage = sm
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.DeleteOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84")
+	sm := newStorageMock()
+	sm.switches[1] = 2
+	req.Storage = sm
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Bang for Delete!", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Bang for Delete!", err.Error())
 }
 
 func TestSignTxFailure1(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
-  sm := newStorageMock()
-  req.Storage = sm
-  req.Data["data"] = "0xabc"
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
+	sm := newStorageMock()
+	req.Storage = sm
+	req.Data["data"] = "0xabc"
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("hex string of odd length", err.Error())
+	assert.Nil(resp)
+	assert.Equal("hex string of odd length", err.Error())
 }
 
 func TestSignTxFailure2(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
-  sm := newStorageMock()
-  req.Storage = sm
-  req.Data["data"] = "0xabcd"
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
+	sm := newStorageMock()
+	req.Storage = sm
+	req.Data["data"] = "0xabcd"
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Error retrieving signing account 0xf809410b0d6f047c603deb311979cd413e025a84", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Error retrieving signing account 0xf809410b0d6f047c603deb311979cd413e025a84", err.Error())
 }
 
 func TestSignTxFailure3(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
-  sm := newStorageMock()
-  sm.switches[1] = 1
-  req.Storage = sm
-  req.Data["data"] = "0xabcd"
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
+	sm := newStorageMock()
+	sm.switches[1] = 1
+	req.Storage = sm
+	req.Data["data"] = "0xabcd"
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Signing account 0xf809410b0d6f047c603deb311979cd413e025a84 does not exist", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Signing account 0xf809410b0d6f047c603deb311979cd413e025a84 does not exist", err.Error())
 }
 
 func TestSignTxFailure4(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
-  sm := newStorageMock()
-  sm.switches[1] = 2
-  req.Storage = sm
-  req.Data["data"] = "0xabcd"
-  req.Data["value"] = "abcd"
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
+	sm := newStorageMock()
+	sm.switches[1] = 2
+	req.Storage = sm
+	req.Data["data"] = "0xabcd"
+	req.Data["value"] = "abcd"
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Invalid amount for the 'value' field", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Invalid amount for the 'value' field", err.Error())
 }
 
 func TestSignTxFailure5(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
-  sm := newStorageMock()
-  sm.switches[1] = 2
-  req.Storage = sm
-  req.Data["data"] = "0xabcd"
-  req.Data["chainId"] = "abcd"
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
+	sm := newStorageMock()
+	sm.switches[1] = 2
+	req.Storage = sm
+	req.Data["data"] = "0xabcd"
+	req.Data["chainId"] = "abcd"
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Invalid 'chainId' value", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Invalid 'chainId' value", err.Error())
 }
 
 func TestSignTxFailure6(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
-  sm := newStorageMock()
-  sm.switches[1] = 2
-  req.Storage = sm
-  req.Data["data"] = "0xabcd"
-  req.Data["gas"] = "abcd"
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
+	sm := newStorageMock()
+	sm.switches[1] = 2
+	req.Storage = sm
+	req.Data["data"] = "0xabcd"
+	req.Data["gas"] = "abcd"
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Invalid gas limit", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Invalid gas limit", err.Error())
 }
 
 func TestSignTxFailure7(t *testing.T) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  b, _ := getBackend(t)
-  req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
-  sm := newStorageMock()
-  sm.switches[1] = 2
-  req.Storage = sm
-  req.Data["data"] = "0xabcd"
-  resp, err := b.HandleRequest(context.Background(), req)
+	b, _ := getBackend(t)
+	req := logical.TestRequest(t, logical.CreateOperation, "accounts/0xf809410b0d6f047c603deb311979cd413e025a84/sign")
+	sm := newStorageMock()
+	sm.switches[1] = 2
+	req.Storage = sm
+	req.Data["data"] = "0xabcd"
+	resp, err := b.HandleRequest(context.Background(), req)
 
-  assert.Nil(resp)
-  assert.Equal("Error reconstructing private key from retrieved hex", err.Error())
+	assert.Nil(resp)
+	assert.Equal("Error reconstructing private key from retrieved hex", err.Error())
 }
 
 func contains(arr []*big.Int, value *big.Int) bool {
-   for _, a := range arr {
-      if a.Cmp(value) == 0 {
-         return true
-      }
-   }
-   return false
+	for _, a := range arr {
+		if a.Cmp(value) == 0 {
+			return true
+		}
+	}
+	return false
 }
-

--- a/backend/path_create_list.go
+++ b/backend/path_create_list.go
@@ -1,30 +1,30 @@
 package backend
 
 import (
-  "github.com/hashicorp/vault/sdk/framework"
-  "github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func pathCreateAndList(b *backend) *framework.Path {
-  return &framework.Path{
-    Pattern: "accounts/?",
-    Callbacks: map[logical.Operation]framework.OperationFunc{
-      logical.ListOperation:    b.listAccounts,
-      logical.UpdateOperation:  b.createAccount,
-    },
-    HelpSynopsis: "List all the Ethereum accounts maintained by the plugin backend and create new accounts.",
-    HelpDescription: `
+	return &framework.Path{
+		Pattern: "accounts/?",
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation:   b.listAccounts,
+			logical.UpdateOperation: b.createAccount,
+		},
+		HelpSynopsis: "List all the Ethereum accounts maintained by the plugin backend and create new accounts.",
+		HelpDescription: `
 
     LIST - list all accounts
     POST - create a new account
 
     `,
-    Fields: map[string]*framework.FieldSchema{
-      "privateKey": &framework.FieldSchema{
-        Type:        framework.TypeString,
-        Description: "Hexidecimal string for the private key (32-byte or 64-char long). If present, the request will import the given key instead of generating a new key.",
-        Default:     "",
-      },
-    },
-  }
+		Fields: map[string]*framework.FieldSchema{
+			"privateKey": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Hexidecimal string for the private key (32-byte or 64-char long). If present, the request will import the given key instead of generating a new key.",
+				Default:     "",
+			},
+		},
+	}
 }

--- a/backend/path_create_list.go
+++ b/backend/path_create_list.go
@@ -19,5 +19,12 @@ func pathCreateAndList(b *backend) *framework.Path {
     POST - create a new account
 
     `,
+    Fields: map[string]*framework.FieldSchema{
+      "privateKey": &framework.FieldSchema{
+        Type:        framework.TypeString,
+        Description: "Hexidecimal string for the private key (32-byte or 64-char long). If present, the request will import the given key instead of generating a new key.",
+        Default:     "",
+      },
+    },
   }
 }

--- a/backend/path_export.go
+++ b/backend/path_export.go
@@ -1,25 +1,25 @@
 package backend
 
 import (
-  "github.com/hashicorp/vault/sdk/framework"
-  "github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func pathExport(b *backend) *framework.Path {
-  return &framework.Path{
-    Pattern:      "export/accounts/" + framework.GenericNameRegex("name"),
-    HelpSynopsis: "Export an Ethereum account",
-    HelpDescription: `
+	return &framework.Path{
+		Pattern:      "export/accounts/" + framework.GenericNameRegex("name"),
+		HelpSynopsis: "Export an Ethereum account",
+		HelpDescription: `
 
     GET - return the account by the name with the private key
 
     `,
-    Fields: map[string]*framework.FieldSchema{
-      "name": &framework.FieldSchema{Type: framework.TypeString},
-    },
-    ExistenceCheck: b.pathExistenceCheck,
-    Callbacks: map[logical.Operation]framework.OperationFunc{
-      logical.ReadOperation:    b.exportAccount,
-    },
-  }
+		Fields: map[string]*framework.FieldSchema{
+			"name": &framework.FieldSchema{Type: framework.TypeString},
+		},
+		ExistenceCheck: b.pathExistenceCheck,
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation: b.exportAccount,
+		},
+	}
 }

--- a/backend/path_export.go
+++ b/backend/path_export.go
@@ -1,0 +1,25 @@
+package backend
+
+import (
+  "github.com/hashicorp/vault/sdk/framework"
+  "github.com/hashicorp/vault/sdk/logical"
+)
+
+func pathExport(b *backend) *framework.Path {
+  return &framework.Path{
+    Pattern:      "export/accounts/" + framework.GenericNameRegex("name"),
+    HelpSynopsis: "Export an Ethereum account",
+    HelpDescription: `
+
+    GET - return the account by the name with the private key
+
+    `,
+    Fields: map[string]*framework.FieldSchema{
+      "name": &framework.FieldSchema{Type: framework.TypeString},
+    },
+    ExistenceCheck: b.pathExistenceCheck,
+    Callbacks: map[logical.Operation]framework.OperationFunc{
+      logical.ReadOperation:    b.exportAccount,
+    },
+  }
+}

--- a/backend/path_read_delete.go
+++ b/backend/path_read_delete.go
@@ -1,28 +1,28 @@
 package backend
 
 import (
-  "github.com/hashicorp/vault/sdk/framework"
-  "github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func pathReadAndDelete(b *backend) *framework.Path {
-  return &framework.Path{
-    Pattern:      "accounts/" + framework.GenericNameRegex("name"),
-    HelpSynopsis: "Create, get or delete an Ethereum account by name",
-    HelpDescription: `
+	return &framework.Path{
+		Pattern:      "accounts/" + framework.GenericNameRegex("name"),
+		HelpSynopsis: "Create, get or delete an Ethereum account by name",
+		HelpDescription: `
 
     POST - create a new account for the given name
     GET - return the account by the name
     DELETE - deletes the account by the name
 
     `,
-    Fields: map[string]*framework.FieldSchema{
-      "name": &framework.FieldSchema{Type: framework.TypeString},
-    },
-    ExistenceCheck: b.pathExistenceCheck,
-    Callbacks: map[logical.Operation]framework.OperationFunc{
-      logical.ReadOperation:    b.readAccount,
-      logical.DeleteOperation:  b.deleteAccount,
-    },
-  }
+		Fields: map[string]*framework.FieldSchema{
+			"name": &framework.FieldSchema{Type: framework.TypeString},
+		},
+		ExistenceCheck: b.pathExistenceCheck,
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation:   b.readAccount,
+			logical.DeleteOperation: b.deleteAccount,
+		},
+	}
 }

--- a/backend/path_sign.go
+++ b/backend/path_sign.go
@@ -1,61 +1,61 @@
 package backend
 
 import (
-  "github.com/hashicorp/vault/sdk/framework"
-  "github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func pathSign(b *backend) *framework.Path {
-  return &framework.Path{
-    Pattern:      "accounts/" + framework.GenericNameRegex("name") + "/sign",
-    HelpSynopsis: "Sign a provided transaction object.",
-    HelpDescription: `
+	return &framework.Path{
+		Pattern:      "accounts/" + framework.GenericNameRegex("name") + "/sign",
+		HelpSynopsis: "Sign a provided transaction object.",
+		HelpDescription: `
 
     Sign a transaction object with properties conforming to the Ethereum JSON-RPC documentation.
 
     `,
-    Fields: map[string]*framework.FieldSchema{
-      "name": &framework.FieldSchema{Type: framework.TypeString},
-      "to": &framework.FieldSchema{
-        Type:        framework.TypeString,
-        Description: "(optional when creating new contract) The contract address the transaction is directed to.",
-        Default:     "",
-      },
-      "data": &framework.FieldSchema{
-        Type:        framework.TypeString,
-        Description: "The compiled code of a contract OR the hash of the invoked method signature and encoded parameters.",
-      },
-      "input": &framework.FieldSchema{
-        Type:        framework.TypeString,
-        Description: "The compiled code of a contract OR the hash of the invoked method signature and encoded parameters.",
-      },
-      "value": &framework.FieldSchema{
-        Type:        framework.TypeString,
-        Description: "(optional) Integer of the value sent with this transaction (in wei).",
-      },
-      "nonce": &framework.FieldSchema{
-        Type:        framework.TypeString,
-        Description: "The transaction nonce.",
-      },
-      "gas": &framework.FieldSchema{
-        Type:        framework.TypeString,
-        Description: "(optional, default: 90000) Integer of the gas provided for the transaction execution. It will return unused gas",
-        Default:     "90000",
-      },
-      "gasPrice": &framework.FieldSchema{
-        Type:        framework.TypeString,
-        Description: "(optional, default: 0) The gas price for the transaction in wei.",
-        Default:     "0",
-      },
-      "chainId": &framework.FieldSchema{
-        Type:        framework.TypeString,
-        Description: "(optional) Chain ID of the target blockchain network. If present, EIP155 signer will be used to sign. If omitted, Homestead signer will be used.",
-        Default:     "0",
-      },
-    },
-    ExistenceCheck: b.pathExistenceCheck,
-    Callbacks: map[logical.Operation]framework.OperationFunc{
-      logical.CreateOperation: b.signTx,
-    },
-  }
+		Fields: map[string]*framework.FieldSchema{
+			"name": &framework.FieldSchema{Type: framework.TypeString},
+			"to": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "(optional when creating new contract) The contract address the transaction is directed to.",
+				Default:     "",
+			},
+			"data": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "The compiled code of a contract OR the hash of the invoked method signature and encoded parameters.",
+			},
+			"input": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "The compiled code of a contract OR the hash of the invoked method signature and encoded parameters.",
+			},
+			"value": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "(optional) Integer of the value sent with this transaction (in wei).",
+			},
+			"nonce": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "The transaction nonce.",
+			},
+			"gas": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "(optional, default: 90000) Integer of the gas provided for the transaction execution. It will return unused gas",
+				Default:     "90000",
+			},
+			"gasPrice": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "(optional, default: 0) The gas price for the transaction in wei.",
+				Default:     "0",
+			},
+			"chainId": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "(optional) Chain ID of the target blockchain network. If present, EIP155 signer will be used to sign. If omitted, Homestead signer will be used.",
+				Default:     "0",
+			},
+		},
+		ExistenceCheck: b.pathExistenceCheck,
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.CreateOperation: b.signTx,
+		},
+	}
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/plugin"
-  "github.com/kaleido-io/vault-plugin-secrets-ethsign/backend"
+	"github.com/kaleido-io/vault-plugin-secrets-ethsign/backend"
 )
 
 func main() {


### PR DESCRIPTION
- added ability to include `privateKey` (in hex format) in the payload when creating new accounts
- added new endpoint `/export/accounts/:account_address` to export the private key. note that the choice of the path, to put `export` upfront instead of the end (like `/accounts/:account_address/export`) is to make it easier to define separate policies for the abilities to display/signTx on an account, vs. exporting the private key:

example user policy:
```
/*
 * Ability to list existing keys ("list")
 */
path "ethereum/accounts" {
  capabilities = ["list"]
}
/*
 * Ability to retrieve individual keys ("read"), sign transactions ("create")
 */
path "ethereum/accounts/*" {
  capabilities = ["create", "read"]
}
```

example admin policy:
```
/*
 * Ability to create key ("update") and list existing keys ("list")
 */
path "ethereum/accounts" {
  capabilities = ["update", "list"]
}
/*
 * Ability to retrieve individual keys ("read"), sign transactions ("create") and delete keys ("delete")
 */
path "ethereum/accounts/*" {
  capabilities = ["create", "read", "delete"]
}
/*
 * Ability to export private keys ("read")
 */
path "ethereum/export/accounts/*" {
  capabilities = ["read"]
}
```